### PR TITLE
Add support for Devtools

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ npm install
 $ NODE_ENV=development gulp hot
 ```
 
+Running in development mode will also enable Redux Devtools so you can easily access the state of the Redux store. Please install the [Redux Devtools extension in Chrome](https://chrome.google.com/webstore/detail/redux-devtools/lmhkpmbekcpmknklioeibfkpmmfibljd?hl=en) to enable this feature.
+
 - Start the electrode app in `production` environment:
 
 ```bash

--- a/client/app.jsx
+++ b/client/app.jsx
@@ -1,22 +1,34 @@
 import React from "react";
 import { routes } from "./routes";
 import { Router } from "react-router";
-import { createStore } from "redux";
+import { createStore, compose } from "redux";
 import { Resolver } from "react-resolver";
 import { createHistory } from "history";
 import { Provider } from "react-redux";
 import "styles/base.css";
 
+import DevTools from "../client/devtools";
+
 const initialState = window.__PRELOADED_STATE__;
 
 const rootReducer = (s, a) => s; // eslint-disable-line no-unused-vars
-const store = createStore(rootReducer, initialState);
+
+const enhancer = compose(
+  // Add middlewares you want to use in development:
+  // applyMiddleware(d1, d2, d3),
+  DevTools.instrument()
+);
+
+const store = createStore(rootReducer, initialState, enhancer);
 
 window.webappStart = () => {
   Resolver.render(
     () =>
       <Provider store={store}>
-        <Router history={createHistory()}>{routes}</Router>
+        <div>
+          <Router history={createHistory()}>{routes}</Router>
+          <DevTools />
+        </div>
       </Provider>,
     document.querySelector(".js-content")
   );

--- a/client/devtools/devtools.dev.js
+++ b/client/devtools/devtools.dev.js
@@ -1,5 +1,5 @@
 import React from "react";
-import {createDevTools} from "redux-devtools";
+import { createDevTools } from "redux-devtools";
 import LogMonitor from "redux-devtools-log-monitor";
 import DockMonitor from "redux-devtools-dock-monitor";
 

--- a/client/devtools/devtools.dev.js
+++ b/client/devtools/devtools.dev.js
@@ -1,0 +1,3 @@
+/**
+ * Created by mgoel1 on 9/21/16.
+ */

--- a/client/devtools/devtools.dev.js
+++ b/client/devtools/devtools.dev.js
@@ -1,3 +1,23 @@
-/**
- * Created by mgoel1 on 9/21/16.
- */
+import React from "react";
+import {createDevTools} from "redux-devtools";
+import LogMonitor from "redux-devtools-log-monitor";
+import DockMonitor from "redux-devtools-dock-monitor";
+
+let DevTools;
+
+if (window.devToolsExtension) {
+  DevTools = () => <div/>;
+  DevTools.instrument = window.devToolsExtension;
+} else {
+  DevTools = createDevTools(
+    <DockMonitor
+      defaultIsVisible={false}
+      toggleVisibilityKey="ctrl-h"
+      changePositionKey="ctrl-q"
+    >
+      <LogMonitor theme="tomorrow"/>
+    </DockMonitor>
+  );
+}
+
+export default DevTools;

--- a/client/devtools/devtools.prod.js
+++ b/client/devtools/devtools.prod.js
@@ -1,0 +1,3 @@
+/**
+ * Created by mgoel1 on 9/21/16.
+ */

--- a/client/devtools/devtools.prod.js
+++ b/client/devtools/devtools.prod.js
@@ -1,3 +1,8 @@
-/**
- * Created by mgoel1 on 9/21/16.
- */
+import React from "react";
+import identity from "lodash/identity";
+
+const DevTools = () => <div />;
+
+DevTools.instrument = () => identity;
+
+export default DevTools;

--- a/client/devtools/index.js
+++ b/client/devtools/index.js
@@ -1,0 +1,3 @@
+/**
+ * Created by mgoel1 on 9/21/16.
+ */

--- a/client/devtools/index.js
+++ b/client/devtools/index.js
@@ -1,3 +1,9 @@
-/**
- * Created by mgoel1 on 9/21/16.
- */
+
+
+//  Note: This is need to prevent the production bundle js from being bloated
+//  with excess stuff from Devtools.
+const DevTools = process.env.NODE_ENV !== "production"
+  ? require("./devtools.dev").default
+  : require("./devtools.prod").default;
+
+export default DevTools;

--- a/client/devtools/index.js
+++ b/client/devtools/index.js
@@ -1,5 +1,4 @@
 
-
 //  Note: This is need to prevent the production bundle js from being bloated
 //  with excess stuff from Devtools.
 const DevTools = process.env.NODE_ENV !== "production"

--- a/package.json
+++ b/package.json
@@ -34,6 +34,9 @@
     "lodash": "^4.10.1"
   },
   "devDependencies": {
+    "redux-devtools": "^3.0.1",
+    "redux-devtools-dock-monitor": "^1.0.1",
+    "redux-devtools-log-monitor": "^1.0.2",
     "electrode-archetype-react-app": "^1.0.0",
     "electrode-archetype-react-app-dev": "^1.0.0",
     "gulp": "^3.9.1"

--- a/package.json
+++ b/package.json
@@ -34,9 +34,9 @@
     "lodash": "^4.10.1"
   },
   "devDependencies": {
-    "redux-devtools": "^3.0.1",
-    "redux-devtools-dock-monitor": "^1.0.1",
-    "redux-devtools-log-monitor": "^1.0.2",
+    "redux-devtools": "^3.3.1",
+    "redux-devtools-dock-monitor": "^1.1.1",
+    "redux-devtools-log-monitor": "^1.0.11",
     "electrode-archetype-react-app": "^1.0.0",
     "electrode-archetype-react-app-dev": "^1.0.0",
     "gulp": "^3.9.1"


### PR DESCRIPTION

**Summary:**
Integrating Redux devtools with the Electrode sample app to allow users to easily debug their application issues. There is not much data in the store given it is a sample application, but it will serve as a reference on integrating devtools with the Electrode app.

**Screenshot:**
![image](https://cloud.githubusercontent.com/assets/10262447/18732357/6b702aac-8017-11e6-833b-7e01ebd9c0cc.png)
