### PR TITLE
Fix proptype from object to string

### DIFF
--- a/client/components/home.jsx
+++ b/client/components/home.jsx
@@ -10,7 +10,7 @@ class HomeWrapper extends React.Component {
 }
 
 HomeWrapper.propTypes = {
-  data: PropTypes.object
+  data: PropTypes.string
 };
 
 export class Home extends React.Component {
@@ -36,7 +36,7 @@ export class Home extends React.Component {
 }
 
 Home.propTypes = {
-  data: PropTypes.object
+  data: PropTypes.string
 };
 
 const mapStateToProps = (state) => ({


### PR DESCRIPTION
Was seeing some issues in the logs on the dev environment.

```
Warning: Failed prop type: Invalid prop `data` of type `string` supplied to `HomeWrapper`, expected `object`.
    in HomeWrapper (created by Connect(HomeWrapper))
    in Connect(HomeWrapper) (created by RouterContext)
    in RouterContext
    in Provider
Warning: Failed prop type: Invalid prop `data` of type `string` supplied to `Home`, expected `object`.
    in Home (created by HomeWrapper)
    in HomeWrapper (created by Connect(HomeWrapper))
    in Connect(HomeWrapper) (created by RouterContext)
    in RouterContext
    in Provider
```

The initial server state here (https://github.com/electrode-io/electrode-boilerplate-universal-react-node/blob/506906c8a64d8047bb56ba9a4ac77ef95038572b/server/views/index-view.jsx#L14) is a string not an object. So updating the proptype to be a string and not an object.