### PR TITLE
Implement critical CSS injection

### DIFF
--- a/client/components/home.jsx
+++ b/client/components/home.jsx
@@ -1,7 +1,7 @@
 import React, {PropTypes} from "react";
 import {connect} from "react-redux";
 import electrodeLogo from "../images/electrode.svg";
-import { container } from '../styles/base.css';
+import { container } from "../styles/base.css";
 
 class HomeWrapper extends React.Component {
   render() {

--- a/client/components/home.jsx
+++ b/client/components/home.jsx
@@ -1,6 +1,7 @@
 import React, {PropTypes} from "react";
 import {connect} from "react-redux";
 import electrodeLogo from "../images/electrode.svg";
+import { container } from '../styles/base.css';
 
 class HomeWrapper extends React.Component {
   render() {
@@ -20,11 +21,7 @@ export class Home extends React.Component {
   render() {
     return (
       <div>
-        <div style={{
-          width: "50%",
-          marginLeft: "auto",
-          marginRight: "auto"
-        }}>
+        <div className={container}>
           <a href="https://github.com/electrode-io"> <img style={{
             width: "100%"
           }} alt="Electrode Logo" src={electrodeLogo}/>

--- a/client/entry.config.js
+++ b/client/entry.config.js
@@ -1,3 +1,0 @@
-module.exports = {
-  entry: "./app.jsx"
-};

--- a/client/styles/base.css
+++ b/client/styles/base.css
@@ -2,6 +2,12 @@ body {
   font: 12px Helvetica;
 }
 
+.container {
+  width: "50%";
+  margin-left: auto;
+  margin-right: auto;
+}
+
 .aboveFold {
   margin: 20px 0;
   border: 2px solid blue;
@@ -17,3 +23,4 @@ input, label {
   margin: 2px;
   display: block;
 }
+

--- a/server/index.js
+++ b/server/index.js
@@ -55,6 +55,6 @@ supports.cssModuleHook({
   generateScopedName: "[name]__[local]___[hash:base64:5]"
 });
 
-supports.isomorphicExtendRequire().then(() => {
+module.exports = supports.isomorphicExtendRequire().then(() => {
   require("electrode-server")(config, [staticPathsDecor()]); // eslint-disable-line
 });

--- a/server/plugins/webapp/index.html
+++ b/server/plugins/webapp/index.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     {{META_TAGS}}
     <title>{{PAGE_TITLE}}</title>
+    {{CRITICAL_CSS}}
     {{PREFETCH_BUNDLES}}
     {{WEBAPP_HEADER_BUNDLES}}
 </head>

--- a/server/plugins/webapp/index.js
+++ b/server/plugins/webapp/index.js
@@ -50,6 +50,12 @@ function getIconStats(iconStatsPath) {
   return iconStats;
 }
 
+function getCriticalCSS(path) {
+  const criticalCSSPath = Path.resolve(process.cwd(), path);
+  const criticalCSS = fs.readFileSync(criticalCSSPath).toString();
+  return `<style>${criticalCSS}</style>`;
+}
+
 function makeRouteHandler(options, userContent) {
   const CONTENT_MARKER = "{{SSR_CONTENT}}";
   const HEADER_BUNDLE_MARKER = "{{WEBAPP_HEADER_BUNDLES}}";
@@ -57,6 +63,7 @@ function makeRouteHandler(options, userContent) {
   const TITLE_MARKER = "{{PAGE_TITLE}}";
   const PREFETCH_MARKER = "{{PREFETCH_BUNDLES}}";
   const META_TAGS_MARKER = "{{META_TAGS}}";
+  const CRITICAL_CSS_MARKER = "{{CRITICAL_CSS}}";
   const WEBPACK_DEV = options.webpackDev;
   const RENDER_JS = options.renderJS;
   const RENDER_SS = options.serverSideRendering;
@@ -65,6 +72,7 @@ function makeRouteHandler(options, userContent) {
   const devJSBundle = options.__internals.devJSBundle;
   const devCSSBundle = options.__internals.devCSSBundle;
   const iconStats = getIconStats(options.iconStats);
+  const criticalCSS = getCriticalCSS(options.criticalCSS);
 
   /* Create a route handler */
   return (request, reply) => {
@@ -128,6 +136,8 @@ function makeRouteHandler(options, userContent) {
           return `<script>${content.prefetch}</script>`;
         case META_TAGS_MARKER:
           return iconStats;
+        case CRITICAL_CSS_MARKER:
+          return criticalCSS;
         default:
           return `Unknown marker ${m}`;
         }
@@ -177,7 +187,8 @@ const registerRoutes = (server, options, next) => {
     },
     paths: {},
     stats: "dist/server/stats.json",
-    iconStats: "dist/server/iconstats.json"
+    iconStats: "dist/server/iconstats.json",
+    criticalCSS: "dist/js/critical.css"
   };
 
   server.route({

--- a/server/plugins/webapp/index.js
+++ b/server/plugins/webapp/index.js
@@ -52,8 +52,12 @@ function getIconStats(iconStatsPath) {
 
 function getCriticalCSS(path) {
   const criticalCSSPath = Path.resolve(process.cwd(), path);
-  const criticalCSS = fs.readFileSync(criticalCSSPath).toString();
-  return `<style>${criticalCSS}</style>`;
+  try {
+    const criticalCSS = fs.readFileSync(criticalCSSPath).toString();
+    return `<style>${criticalCSS}</style>`;
+  } catch (err) {
+    return '';
+  }
 }
 
 function makeRouteHandler(options, userContent) {

--- a/server/plugins/webapp/index.js
+++ b/server/plugins/webapp/index.js
@@ -9,6 +9,14 @@ const assert = require("assert");
 const HTTP_ERROR_500 = 500;
 const HTTP_REDIRECT = 302;
 
+const CONTENT_MARKER = "{{SSR_CONTENT}}";
+const HEADER_BUNDLE_MARKER = "{{WEBAPP_HEADER_BUNDLES}}";
+const BODY_BUNDLE_MARKER = "{{WEBAPP_BODY_BUNDLES}}";
+const TITLE_MARKER = "{{PAGE_TITLE}}";
+const PREFETCH_MARKER = "{{PREFETCH_BUNDLES}}";
+const META_TAGS_MARKER = "{{META_TAGS}}";
+const CRITICAL_CSS_MARKER = "{{CRITICAL_CSS}}";
+
 /**
  * Load stats.json which is created during build.
  * The file contains bundle files which are to be loaded on the client side.
@@ -56,18 +64,11 @@ function getCriticalCSS(path) {
     const criticalCSS = fs.readFileSync(criticalCSSPath).toString();
     return `<style>${criticalCSS}</style>`;
   } catch (err) {
-    return '';
+    return "";
   }
 }
 
 function makeRouteHandler(options, userContent) {
-  const CONTENT_MARKER = "{{SSR_CONTENT}}";
-  const HEADER_BUNDLE_MARKER = "{{WEBAPP_HEADER_BUNDLES}}";
-  const BODY_BUNDLE_MARKER = "{{WEBAPP_BODY_BUNDLES}}";
-  const TITLE_MARKER = "{{PAGE_TITLE}}";
-  const PREFETCH_MARKER = "{{PREFETCH_BUNDLES}}";
-  const META_TAGS_MARKER = "{{META_TAGS}}";
-  const CRITICAL_CSS_MARKER = "{{CRITICAL_CSS}}";
   const WEBPACK_DEV = options.webpackDev;
   const RENDER_JS = options.renderJS;
   const RENDER_SS = options.serverSideRendering;

--- a/server/plugins/webapp/index.js
+++ b/server/plugins/webapp/index.js
@@ -116,14 +116,20 @@ function makeRouteHandler(options, userContent) {
         ? `<link rel="manifest" href="${manifest}" />`
         : "";
       const css = bundleCss();
-      const cssLink = css ? `<link rel="stylesheet" href="${css}" />` : "";
+      const cssLink = css && !criticalCSS
+        ? `<link rel="stylesheet" href="${css}" />`
+        : "";
       return `${manifestLink}${cssLink}`;
     };
 
     const makeBodyBundles = () => {
       const js = bundleJs();
+      const css = bundleCss();
+      const cssLink = css && criticalCSS
+      ? `<link rel="stylesheet" href="${css}" />`
+      : "";
       const jsLink = js ? `<script src="${js}"></script>` : "";
-      return jsLink;
+      return `${cssLink}${jsLink}`;
     };
 
     const renderPage = (content) => {


### PR DESCRIPTION
Moves some inline styles to external files to demonstrate critical CSS inlining. Adds a new marker to `webapp` that injects a style tag with the parsed critical css.